### PR TITLE
chore(config-api): enable preferIPv4Stack for tests

### DIFF
--- a/config-api/pom.xml
+++ b/config-api/pom.xml
@@ -102,6 +102,7 @@
             <properties>
               <cargo.servlet.port>${jboss.http.port}</cargo.servlet.port>
               <cargo.jboss.management.port>${jboss.management.port}</cargo.jboss.management.port>
+              <cargo.jvmargs>-Djava.net.preferIPv4Stack=true</cargo.jvmargs>
             </properties>
           </configuration>
           <deployables>


### PR DESCRIPTION
The swarm build started to fail similar to [CAM-10881](https://app.camunda.com/jira/browse/CAM-10881)